### PR TITLE
Prepend PUBLIC_URL to img src for navbar and loader images

### DIFF
--- a/src/components/Loader.js
+++ b/src/components/Loader.js
@@ -4,7 +4,7 @@ import './Loader.scss';
 const Loader = ({ isLoading }) => (
   <div className={`page-loader${isLoading ? " on" : " off"}`}>
     <div className="gif-container">
-      <img src="loading.gif" alt="page loader animation" width="50" />
+      <img src={process.env.PUBLIC_URL + '/loading.gif'} alt="page loader animation" width="50" />
     </div>
   </div>
 )

--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -68,9 +68,9 @@ const NavBar = () => {
             {isAuthenticated && user && (
               <>
                 <img className="nav__avatar" src={user.picture} alt="User avatar" width="32" />
-                <img className="nav_dropdownIconOpen" src="arrow-down-sign-to-navigate.svg" alt="dropdown open" onClick={() => setOpen(true)} />
-                <img className="nav_dropdownIconClose" src="close-button.svg" alt="dropdown close" onClick={() => setOpen(false)} />
-                <img className="nav__mobile-menu-btn" src="menu-button.svg" alt="mobile menu" width="32" onClick={() => setOpen(!open)} />
+                <img className="nav_dropdownIconOpen" src={process.env.PUBLIC_URL + '/arrow-down-sign-to-navigate.svg'} alt="dropdown open" onClick={() => setOpen(true)} />
+                <img className="nav_dropdownIconClose" src={process.env.PUBLIC_URL + '/close-button.svg'} alt="dropdown close" onClick={() => setOpen(false)} />
+                <img className="nav__mobile-menu-btn" src={process.env.PUBLIC_URL + '/menu-button.svg'} alt="mobile menu" width="32" onClick={() => setOpen(!open)} />
                 <LoggedInDropdown open={open} />
               </>
             )}


### PR DESCRIPTION
This fixes the broken images when attempting to visit the site without a trailing slash (eg https://fz5dii7b6h.execute-api.us-east-1.amazonaws.com/dev-matt).

Had to change the img `src` property with a manually generated url since relative linking breaks when a user visits the homepage without a slash. Only relevant for navbar, loader and homepage images.